### PR TITLE
Update policies with an enforcement level

### DIFF
--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -1,7 +1,9 @@
 policy "managed-disk-encryption-is-enabled" {
   source = "./policies/managed-disk-encryption-is-enabled/managed-disk-encryption-is-enabled.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "only-approved-extensions-are-installed" {
   source = "./policies/only-approved-extensions-are-installed/only-approved-extensions-are-installed.sentinel"
+  enforcement_level = "advisory"
 }


### PR DESCRIPTION
While enforcement level is optional in Sentinel 0.18.11 (June 2022) and above, older sentinel clients will throw errors.  For now add this in so that older sentinel binaries don't error with for no reason.